### PR TITLE
Improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,10 @@
 # Directories
 .terraform/
 .vagrant/
+
+# certs
 files/ptfe_server.crt
 files/ptfe_server.key
+
+# this contains auth tokens
 modules/variables.auto.tfvars

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@
 # Directories
 .terraform/
 .vagrant/
+files/ptfe_server.crt
+files/ptfe_server.key
+modules/variables.auto.tfvars

--- a/README.md
+++ b/README.md
@@ -1,71 +1,71 @@
 # ptfe-vagrant
-Vagrant Environment for auto install pTFE including Gitlab VCS
 
-### Overview
+Vagrant Environment for auto install pTFE including GitLab VCS
+
+## Overview
 
 This vagrant environment will provision two Ubuntu VirtualBox machines:
- - Private Terraform Enterprise Server
- - Gitlab EE Server
 
- *Important:* BYOL (Bring your own license) Installation requires you have a .rli license file
+- Private Terraform Enterprise Server
+- GitLab EE Server
 
-### Instructions
+## Requirements
 
-- Step 1: Copy the .rli file into the /files directory as license.rli
+BYOL (Bring your own license) installation requires you have a `.rli` license file
 
-- Step 2: Update the config.yaml with any custom settings (domain/ipaddresses)
+## Instructions
 
-- Step 3: `vagrant up`
+1. Copy your `.rli` file into the `/files` directory as `license.rli`
+2. Update the `config.yaml` with any custom settings (domain/ip addresses)
+3. Generate SSL certificate and import to MacOS Keychain
 
-- Step 4: Set your hosts file to resolve the domains/ipaddrs
+   ```shell
+   DOMAIN='local' # get this value from config.yaml
+   openssl req -new -days 365 -nodes -x509 -subj "/C=US/ST=California/L=San Francisco/O=HashiCorp/CN=ptfe.${DOMAIN}" -keyout "./files/ptfe_server.key" -out "./files/ptfe_server.crt"
 
-```
-#/etc/hosts
+   open "./files/ptfe_server.crt"
+   ```
 
-10.0.0.50 ptfe.local
-10.0.0.51 gitlab.local
+4. Run `vagrant up`
+5. Set your hosts file to resolve the domains/ip addresses
 
-# Hack-y, but works..
-10.0.0.50	archivist.ptfe
-10.0.0.50	atlas.ptfe
-10.0.0.50	influxdb.ptfe
-10.0.0.50	nginx.ptfe
-10.0.0.50	nomad.ptfe
-10.0.0.50	postgres
-10.0.0.50	rabbitmq
-10.0.0.50	redis
-10.0.0.50	slug-ingress.ptfe
-10.0.0.50	telegraf.ptfe
-10.0.0.50	terraform-state-parser.ptfe
-10.0.0.50	vault.ptfe
+   ```shell
+   #/etc/hosts
 
-```
+   10.0.0.50 ptfe.local
+   10.0.0.51 gitlab.local
 
-- Step 5: Finish ptfe setup at http://ptfe.local:8800
-  - Login with [unlock password](https://github.com/sshastri/ptfe-vagrant/blob/master/files/replicated.conf#L3) 
-  - Create admin account/password
-  - Create user token
-  - Rename /modules/variables.auto.tfvars.example -> /modules/variables.auto.tfvars. Set token
+   # Hack-y, but works..
+   10.0.0.50 archivist.ptfe
+   10.0.0.50 atlas.ptfe
+   10.0.0.50 influxdb.ptfe
+   10.0.0.50 nginx.ptfe
+   10.0.0.50 nomad.ptfe
+   10.0.0.50 postgres
+   10.0.0.50 rabbitmq
+   10.0.0.50 redis
+   10.0.0.50 slug-ingress.ptfe
+   10.0.0.50 telegraf.ptfe
+   10.0.0.50 terraform-state-parser.ptfe
+   10.0.0.50 vault.ptfe
+   ```
 
-- Step 6: Finish gitlab server setup at http://gitlab.local
-  - Set the root password
-  - Login
-  - Create a token (http://gitlab.local/profile/personal_access_tokens). Set token in variables.auto.tfvars
+6. Finish pTFE setup at <http://ptfe.local:8800>
+     - Login with [unlock password](https://github.com/sshastri/ptfe-vagrant/blob/master/files/replicated.conf#L3)
+     - Create admin account/password
+     - Create user token
+     - Rename `./modules/variables.auto.tfvars.example` -> `./modules/variables.auto.tfvars`
+     - Set token in `./modules/variables.auto.tfvars`
+7. Finish GitLab server setup at http://gitlab.local
+     - Set the root password
+     - Login
+     - Create a token (<http://gitlab.local/profile/personal_access_tokens>)
+     - Set token in `./modules/variables.auto.tfvars`
+8. Run Terraform
 
-- Step 7: Run Terraform
-```
-  cd ./modules
-  terraform init
-  terraform plan
-  terraform apply
-```
-
-If you get this error:
- ```
- Error: Error running plan: 1 error(s) occurred:
-
-* provider.tfe: Failed to request discovery document: Get https://ptfe.local/.well-known/terraform.json: x509: certificate signed by unknown authority
-````
-
-_Workaround_ The certificate at /etc/ptfe_server.crt on the ptfe box needs to be added to the Mac OS Keychain. Copy the cert from the vagrant box and File -> Import Items... to select the certificate.
-TODO: Figure out a way to automate this.
+   ```shell
+   cd ./modules
+   terraform init
+   terraform plan
+   terraform apply
+   ```

--- a/README.md
+++ b/README.md
@@ -61,6 +61,12 @@ BYOL (Bring your own license) installation requires you have a `.rli` license fi
      - Login
      - Create a token (<http://gitlab.local/profile/personal_access_tokens>)
      - Set token in `./modules/variables.auto.tfvars`
+     - Enable outbound requests to pTFE [in the Admin Area](http://gitlab.local/admin/application_settings/network#js-outbound-settings) ([see why this is needed](https://docs.gitlab.com/ee/security/webhooks.html))
+        1. Go to Admin Area -> Settings -> Network
+        2. Expand Outbound requests
+        3. Select the "Allow requests to the local network from system hooks" checkbox
+        4. Add the pTFE hostname to the "Whitelist to allow requests to the local network from hooks and services" text box
+        5. Save changes
 8. Run Terraform
 
    ```shell

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -37,7 +37,7 @@ Vagrant.configure("2") do |config|
     s.vm.provider "virtualbox" do |vb|
       vb.gui = false
       vb.cpus = 1
-      vb.memory = 1024
+      vb.memory = 2048
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
     end

--- a/modules/main.tf
+++ b/modules/main.tf
@@ -28,5 +28,5 @@ resource "tfe_oauth_client" "gitlab" {
   api_url          = "http://gitlab.local/api/v4"
   http_url         = "https://gitlab.local"
   oauth_token      = "${var.gitlab_oauth}"
-  service_provider = "gitlab_enterprise_edition"
+  service_provider = "gitlab_community_edition"
 }

--- a/modules/variables.auto.tfvars.example
+++ b/modules/variables.auto.tfvars.example
@@ -1,0 +1,8 @@
+# Uncomment and replace these with the actual tokens
+#token = "PTFE_TOKEN"
+#gitlab_oauth = "GITLAB_API_TOKEN"
+
+hostname = "ptfe.local"
+org_name = "HashiCorp"
+team_name = "IS"
+workspace_name = "Vagrant"

--- a/scripts/install_ptfe.sh
+++ b/scripts/install_ptfe.sh
@@ -9,8 +9,9 @@ apt-get install -y jq
 # Application Settings for PTFE
 jq --arg fqdn $fqdn '.hostname.value = $fqdn' /vagrant/files/ptfe_settings.json > /tmp/ptfe_settings.json
 
-# Create SSL Cert and Key
-openssl req -new -days 365 -nodes -x509 -subj "/C=US/ST=Oregon/L=Portland/O=Hashicorp/CN=$fqdn" -keyout "/etc/ptfe_server.key" -out "/etc/ptfe_server.crt"
+# Copy SSL cert and key
+cp /vagrant/files/ptfe_server.* /etc
+chmod 0600 /etc/ptfe_server.key
 
 # Copy over the license file
 cp /vagrant/files/license.rli /tmp/license.rli


### PR DESCRIPTION
- Move SSL cert generation to host to make it easier to import it to the host trust store
- Update README.md to match the change above
- Fix markdown lint warnings/errors 
- Increase GitLab VM memory to 2GB because it uses 1.5GB minimum, and was running out of memory
- Add missing `variables.auto.tfvars.example` file referenced in the README.md
- Add additional instructions required for recent versions of GitLab
